### PR TITLE
Changes for using glycol and direct heat on an SSBrewtech Unitank

### DIFF
--- a/src/Brewpi.h
+++ b/src/Brewpi.h
@@ -42,7 +42,7 @@ license and credits. */
 #define BREWPI_SHIELD_SPARK_REV_C 3     // Here for reference - this isn't actually supported in this firmware
 #define BREWPI_SHIELD_SPARK_REV_C2 4    // Here for reference - this isn't actually supported in this firmware
 #define BREWPI_SHIELD_I2C 5             // For hardware Uno shields with I2C on A4/A5
-#define BREWPI_SHIELD_GLYCOL 5          // For hardware Uno shields with I2C on A4/A5
+#define BREWPI_SHIELD_GLYCOL 6          // For hardware Uno shields with I2C on A4/A5
 
 #define BREWPI_BOARD_LEONARDO 'l'
 #define BREWPI_BOARD_STANDARD 's'

--- a/src/Brewpi.h
+++ b/src/Brewpi.h
@@ -42,7 +42,7 @@ license and credits. */
 #define BREWPI_SHIELD_SPARK_REV_C 3     // Here for reference - this isn't actually supported in this firmware
 #define BREWPI_SHIELD_SPARK_REV_C2 4    // Here for reference - this isn't actually supported in this firmware
 #define BREWPI_SHIELD_I2C 5             // For hardware Uno shields with I2C on A4/A5
-#define BREWPI_SHIELD_GLYCOL 6          // For hardware Uno shields with I2C on A4/A5
+#define BREWPI_SHIELD_GLYCOL 5          // For hardware Uno shields with I2C on A4/A5
 
 #define BREWPI_BOARD_LEONARDO 'l'
 #define BREWPI_BOARD_STANDARD 's'

--- a/src/TempControl.cpp
+++ b/src/TempControl.cpp
@@ -97,11 +97,19 @@ void TempControl::init(void)
 		beerSensor->init();
 	}
 
+#if BREWPI_STATIC_CONFIG != BREWPI_SHIELD_GLYCOL
 	if (fridgeSensor == NULL)
 	{
 		fridgeSensor = new TempSensor(TEMP_SENSOR_TYPE_FRIDGE, &defaultTempSensor);
 		fridgeSensor->init();
 	}
+#else
+        // use the beer sensor as the fridge sensor when using glycol
+	if (fridgeSensor == NULL)
+	{
+		fridgeSensor = beerSensor;
+	}
+#endif
 
 	updateTemperatures();
 	reset();

--- a/src/TempControl.h
+++ b/src/TempControl.h
@@ -63,13 +63,13 @@ const uint16_t HEAT_PEAK_DETECT_TIME = 900;
 #else
 // Glycol support constants
 const uint16_t MIN_COOL_OFF_TIME = 0;
-const uint16_t MIN_HEAT_OFF_TIME = 300;
+const uint16_t MIN_HEAT_OFF_TIME = 30;
 const uint16_t MIN_COOL_ON_TIME = 0;
-const uint16_t MIN_HEAT_ON_TIME = 180;
+const uint16_t MIN_HEAT_ON_TIME = 30;
 const uint16_t MIN_COOL_OFF_TIME_FRIDGE_CONSTANT = 0;
-const uint16_t MIN_SWITCH_TIME = 600;
-const uint16_t COOL_PEAK_DETECT_TIME = 1800;
-const uint16_t HEAT_PEAK_DETECT_TIME = 900;
+const uint16_t MIN_SWITCH_TIME = 30;
+const uint16_t COOL_PEAK_DETECT_TIME = 180;
+const uint16_t HEAT_PEAK_DETECT_TIME = 180;
 #endif
 
 // These two structs are stored in and loaded from EEPROM


### PR DESCRIPTION
`BREWPI_SHIELD_GLYCOL` needs to be set to 5, otherwise the script doesn't know that it is supposed to be using an I2C shield when the firmware is compiled for glycol.

The most straightforward way to get glycol and direct heat to behave is to configure the temperature sensor as a beer sensor and the in the firmware, pull the fridge temperature from the beer sensor.

I also tightened the minimums on short cycle.